### PR TITLE
partial namespace matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,15 @@ prompt:
 
 # Behavior
 behavior:
-    # Make sure the namespace exists with `kubectl get namespaces` when switching
-    # namespaces. If you do not have the right to list namespaces, disable this.
+    # Namespace validation and switching behavior.  Set to "false" if you do not have
+    # the right to list namespaces.
+    # Valid values:
+    #  true:    make sure the namespace exists with `kubectl get namespaces`
+    #  false:   switch namespaces without validation
+    #  partial: check for partial matches when running `kubie ns <namespace>`
+    #           and no exact match is found:
+    #             - if exactly one namespace partially matches, switch to that namespace
+    #             - if multiple namespaces partially match, select from those
     # Default: true
     validate_namespaces: true
 

--- a/README.md
+++ b/README.md
@@ -151,12 +151,12 @@ behavior:
     # Namespace validation and switching behavior.  Set to "false" if you do not have
     # the right to list namespaces.
     # Valid values:
-    #  true:    make sure the namespace exists with `kubectl get namespaces`
-    #  false:   switch namespaces without validation
-    #  partial: check for partial matches when running `kubie ns <namespace>`
-    #           and no exact match is found:
-    #             - if exactly one namespace partially matches, switch to that namespace
-    #             - if multiple namespaces partially match, select from those
+    #   true:    Make sure the namespace exists with `kubectl get namespaces`.
+    #   false:   Switch namespaces without validation.
+    #   partial: Check for partial matches when running `kubie ns <namespace>`
+    #            and no exact match is found:
+    #              - if exactly one namespace partially matches, switch to that namespace
+    #              - if multiple namespaces partially match, select from those
     # Default: true
     validate_namespaces: true
 

--- a/src/cmd/context.rs
+++ b/src/cmd/context.rs
@@ -37,7 +37,7 @@ fn enter_context(
         kubeconfig.contexts[0].context.namespace.as_deref(),
     );
 
-    if settings.behavior.validate_namespaces {
+    if settings.behavior.validate_namespaces.can_list_namespaces() {
         if let Some(namespace_name) = namespace_name {
             let namespaces = kubectl::get_namespaces(Some(&kubeconfig))?;
             if !namespaces.iter().any(|x| x == namespace_name) {

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -59,8 +59,9 @@ pub fn select_or_list_context(skim_options: &SkimOptions, installed: &mut Instal
     }
 }
 
-pub fn select_or_list_namespace(skim_options: &SkimOptions) -> Result<SelectResult> {
-    let mut namespaces = kubectl::get_namespaces(None)?;
+pub fn select_or_list_namespace(skim_options: &SkimOptions, namespaces: Option<Vec<String>>) -> Result<SelectResult> {
+    let mut namespaces = namespaces.unwrap_or_else(|| kubectl::get_namespaces(None).expect("could not get namespaces"));
+
     namespaces.sort();
 
     if namespaces.is_empty() {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -166,19 +166,28 @@ impl ContextHeaderBehavior {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default)]
 pub struct Behavior {
-    #[serde(default = "def_bool_true")]
-    pub validate_namespaces: bool,
+    #[serde(default)]
+    pub validate_namespaces: ValidateNamespacesBehavior,
     #[serde(default)]
     pub print_context_in_exec: ContextHeaderBehavior,
 }
 
-impl Default for Behavior {
-    fn default() -> Self {
-        Behavior {
-            validate_namespaces: true,
-            print_context_in_exec: Default::default(),
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ValidateNamespacesBehavior {
+    #[default]
+    True,
+    False,
+    Partial,
+}
+
+impl ValidateNamespacesBehavior {
+    pub fn can_list_namespaces(&self) -> bool {
+        match self {
+            ValidateNamespacesBehavior::True | ValidateNamespacesBehavior::Partial => true,
+            ValidateNamespacesBehavior::False => false,
         }
     }
 }


### PR DESCRIPTION
_I've found this enhancement to be very useful in accommodating my own ~laziness~ workflow, so figured I'd submit for inclusion if interested : )_

Adds a third option, `partial`, to the `validate_namespaces` behavior setting, which causes `kubie ns <ns>` to perform a check for partial matches when an exact namespace match is not found.

For example, on a cluster with an `ingress-system` namespace, running `kubie ns ingress` would switch to `ingress-system`.

Running `kubie ns system` would bring up the select-or-list interface showing, i.e., `gatekeeper-system`, `ingress-system` and `kube-system`.

The existing `true` and `false` values retain their original behavior, with the default remaining `true`.  This change is backwards-compatible and requires no updates to `kubie.yaml`, unless one chooses to enable `partial`.